### PR TITLE
fix(fzy): reach fzy.score key

### DIFF
--- a/lua/fzy/original.lua
+++ b/lua/fzy/original.lua
@@ -220,7 +220,7 @@ function fzy.filter_table_ordered(needle, items)
     end
   end
 
-  table.sort(results, function(i, j) return i.score > j.score end)
+  table.sort(results, function(i, j) return i.fzy.score > j.fzy.score end)
   return results
 end
 


### PR DESCRIPTION
The score is located under the `fzy` key of the `item`.
Sorry my previous PR forgot to fix this typo.
It should work OK now :)