### PR TITLE
Fix deprecation warning change telescope.path to plenary.path

### DIFF
--- a/lua/fzy/original.lua
+++ b/lua/fzy/original.lua
@@ -9,7 +9,7 @@
 -- > matches on consecutive letters and starts of words. This allows matching
 -- > using acronyms or different parts of the path." - J Hawthorn
 
-local has_path, path = pcall(require, 'telescope.path')
+local has_path, path = pcall(require, 'plenary.path')
 if not has_path then
   path = {
     separator = '/'


### PR DESCRIPTION
See here: https://github.com/nvim-telescope/telescope.nvim/issues/387