### PR TITLE
fix: helper.is_installed now correctly reports installation status on Windows

### DIFF
--- a/lua/guihua/helper.lua
+++ b/lua/guihua/helper.lua
@@ -1,12 +1,16 @@
 local uv = vim.loop
 local DIR_SEP = package.config:sub(1, 1)
+local os_name = uv.os_uname().sysname
+local is_windows = os_name == 'Windows' or os_name == 'Windows_NT'
+local path_sep = is_windows and ";" or ":"
+local exe = is_windows and ".exe" or ""
 
 local function is_installed(bin)
   local env_path = os.getenv('PATH')
-  local base_paths = vim.split(env_path, ':', true)
+  local base_paths = vim.split(env_path, path_sep, true)
 
   for key, value in pairs(base_paths) do
-    if uv.fs_stat(value .. DIR_SEP .. bin) then
+    if uv.fs_stat(value .. DIR_SEP .. bin .. exe) then
       return true
     end
   end


### PR DESCRIPTION
This allows helper.is_installed to correctly report a program's installation status on Windows systems.